### PR TITLE
saveTimer feature

### DIFF
--- a/src/fr/maxlego08/zscheduler/api/SchedulerType.java
+++ b/src/fr/maxlego08/zscheduler/api/SchedulerType.java
@@ -1,5 +1,7 @@
 package fr.maxlego08.zscheduler.api;
 
+import java.util.concurrent.TimeUnit;
+
 public enum SchedulerType {
 
     HOURLY,
@@ -17,6 +19,21 @@ public enum SchedulerType {
 
     public boolean isRepeatScheduler() {
         return this == EVERY_DAY || this == EVERY_HOUR || this == EVERY_MINUTE || this == EVERY_SECOND;
+    }
+
+    public TimeUnit convertToTimeUnit() {
+        switch (this) {
+            case EVERY_DAY:
+                return TimeUnit.DAYS;
+            case EVERY_HOUR:
+                return TimeUnit.HOURS;
+            case EVERY_MINUTE:
+                return TimeUnit.MINUTES;
+            case EVERY_SECOND:
+                return TimeUnit.SECONDS;
+            default:
+                return null;
+        }
     }
 
 }

--- a/src/fr/maxlego08/zscheduler/api/schedulers/RepeatScheduler.java
+++ b/src/fr/maxlego08/zscheduler/api/schedulers/RepeatScheduler.java
@@ -33,7 +33,7 @@ public class RepeatScheduler implements Scheduler {
     private Implementation implementation;
     private ScheduledFuture<?> scheduledFuture;
     private Instant lastExecution;
-    private boolean saveTimer;
+    private final boolean saveTimer;
 
     public RepeatScheduler(SchedulerPlugin plugin, String name, SchedulerType schedulerType, long initialDelay, boolean saveTimer, long period, int minPlayer, List<String> commands, String implementationName, Map<String, Object> implementationValues) {
         this.plugin = plugin;

--- a/src/main/resources/schedulers.yml
+++ b/src/main/resources/schedulers.yml
@@ -75,9 +75,10 @@ schedulers:
     commands:
       - "bc Broadcast message every first of year at 00h00"
 
-  # example5:
-  #   type: EVERY_MINUTE
-  #  initialDelay: 0
-  #  period: 1
-  #  commands:
-  #    - "bc &fHey its run every minute !"
+#  example5:
+#    type: EVERY_MINUTE
+#    initialDelay: 0
+#    period: 1
+#    saveTimer: true
+#    commands:
+#      - "bc &fHey its run every minute !"


### PR DESCRIPTION
Solves #6 .
When the server shuts down, all RepeatSchedulers save the seconds that has passed since their last execution to previousExecutions.json. This way, when starts back up, we use this information to override initialDelay and start the scheduler at the right time.